### PR TITLE
Merge profiles into master to extend functionality

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,2 @@
+rm -rf CMakeFiles CMakeCache.txt _skbuild
+rm record main ambilight record ambilight *.cmake *.so*

--- a/libmk/libmk.c
+++ b/libmk/libmk.c
@@ -178,18 +178,6 @@ const unsigned char LIBMK_LAYOUT[2][3][LIBMK_MAX_ROWS][LIBMK_MAX_COLS] = {
 };
 
 
-const char* LIBMK_MODEL_STRINGS[] = {
-    "MasterKeys Pro L RGB", // 0
-    "MasterKeys Pro S RGB", // 1
-    "MasterKeys Pro L White", // 2
-    "MasterKeys Pro M White", // 3
-    "Unknown Model", // 4
-    "MasterKeys Pro M RGB", // 5
-    "Unknown Model", // 6
-    "MasterKeys Pro S White",
-};
-
-
 bool libmk_init(void) {
     int result = libusb_init(&Context);
 #ifdef LIBMK_USB_DEBUG
@@ -472,9 +460,9 @@ int libmk_enable_control(LibMK_Handle* handle) {
 
 
 int libmk_send_control_packet(LibMK_Handle* handle) {
-    r = libmk_set_control_mode(handle, LIBMK_CUSTOM_CTRL);
+    int r = libmk_set_control_mode(handle, LIBMK_CUSTOM_CTRL);
     if (r != LIBMK_SUCCESS)
-        return LIBMK_ERR_SEND;
+        return r;
     LibMK_Firmware* fw;
     r = libmk_get_firmware_version(handle, &fw);
     if (r != LIBMK_SUCCESS) {
@@ -565,40 +553,16 @@ int libmk_set_full_color(LibMK_Handle* handle,
 
 
 int libmk_send_packet(LibMK_Handle* handle, unsigned char* packet) {
-<<<<<<< HEAD
-=======
-    /** Send a single packet of data to the specified device
-     *
-     * Calls libmk_send_recv_packet but instructs it not to care about
-     * receiving a response.
-    */
     return libmk_send_recv_packet(handle, packet, true);
 }
 
 
 int libmk_send_recv_packet(
         LibMK_Handle* handle, unsigned char* packet, bool response_required) {
-    /** Send a single packet of data to the specified device
-     *
-     * The device operates in INTERRUPT mode, expects 64 bytes of data
-     * every time. First sends the packet to the device OUT endpoint,
-     * then reads a packet from the device IN endpoint. If the packet
-     * was correctly formatted, this received packet has the same header
-     * as the packet sent. If the header is HEADER_ERROR, then a
-     * protocol error has occurred and the packet was rejected.
-     *
-     * response_required: Boolean argument that determines whether an
-     *   acknowledgement packet is required from the keyboard. Nearly
-     *   all operations yield a confirmation packet, but some do not. If
-     *   it is not required, the function will still attempt to retrieve
-     *   a response, but not care if it is not available.
-    */
     if (handle == NULL)
         handle = DeviceHandle;
     if (handle == NULL)
         return LIBMK_ERR_DEV_NOT_SET;
-    
->>>>>>> 748c903... Fix errors during profile control
     int t, result;
     int r = libusb_interrupt_transfer(
         handle->handle, LIBMK_EP_OUT | LIBUSB_ENDPOINT_OUT,

--- a/libmk/libmk.c
+++ b/libmk/libmk.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define LIBMK_DEBUG
+// #define LIBMK_DEBUG
 // #define LIBMK_USB_DEBUG
 
 #ifndef LIBMK_DEBUG
@@ -446,21 +446,7 @@ int libmk_enable_control(LibMK_Handle* handle) {
         return LIBMK_ERR_IFACE_CLAIM_FAILED;
 
     // Send the enable control packet to the keyboard
-<<<<<<< HEAD
     return libmk_send_control_packet(handle);
-=======
-    r = libmk_send_control_packet(handle);
-    if (r != LIBMK_SUCCESS)
-        return LIBMK_ERR_SEND;
-    LibMK_Firmware* fw;
-    r = libmk_get_firmware_version(handle, &fw);
-    if (r != LIBMK_SUCCESS) {
-        libusb_close(handle->handle);
-        return r;
-    }
-    handle->layout = fw->layout;
-    return LIBMK_SUCCESS;
->>>>>>> ce36524... Fix libmk_create_handle
 }
 
 
@@ -472,12 +458,6 @@ int libmk_send_control_packet(LibMK_Handle* handle) {
         return r;
     unsigned char* packet = libmk_build_packet(
         2, HEADER_DEFAULT, OPCODE_ENABLE);
-    return libmk_send_packet(handle, packet);
-}
-
-
-int libmk_send_flush_packet(LibMK_Handle* handle) {
-    unsigned char* packet = libmk_build_packet(2, 0x50, 0x55);
     return libmk_send_packet(handle, packet);
 }
 
@@ -547,10 +527,7 @@ int libmk_set_effect(LibMK_Handle* handle, LibMK_Effect effect) {
     packet = libmk_build_packet(
         5, HEADER_DEFAULT | HEADER_EFFECT, OPCODE_EFFECT,
         0x00, 0x00, (unsigned char) effect);
-    r = libmk_send_packet(handle, packet);
-    if (r != LIBMK_SUCCESS)
-        return r;
-    return libmk_send_flush_packet(handle);
+    return libmk_send_packet(handle, packet);
 }
 
 
@@ -680,26 +657,17 @@ int libmk_set_all_led_color(LibMK_Handle* handle, unsigned char* colors) {
                     (r * LIBMK_MAX_COLS + c) * 3 + o];
             }
         }
-
-    int r = libmk_send_flush_packet(handle);
-    if (r != LIBMK_SUCCESS)
-        return r;
+        
     for (short k = 0; k < LIBMK_ALL_LED_PCK_NUM; k++) {
-        r = libmk_send_packet(handle, packets[k]);
+        int r = libmk_send_packet(handle, packets[k]);
         if (r != LIBMK_SUCCESS)
             return r;
     }
-    unsigned char* flush = libmk_build_packet(2, 0x50, 0x55);
-    return libmk_send_packet(handle, flush);
+    return LIBMK_SUCCESS;
 }
 
 
-<<<<<<< HEAD
-inline void libmk_print_packet(unsigned char* packet) {
-=======
 inline void libmk_print_packet(unsigned char* packet, char* label) {
-    /** Pretty print a keyboard communication packet */
->>>>>>> ce36524... Fix libmk_create_handle
 #ifdef LIBMK_DEBUG
     printf("Packet: %s\n", label);
     for (unsigned char j = 0; j < LIBMK_PACKET_SIZE; j++) {

--- a/libmk/libmk.c
+++ b/libmk/libmk.c
@@ -768,3 +768,40 @@ int libmk_get_firmware_version(LibMK_Handle* handle, LibMK_Firmware** fw) {
     (*fw)->layout = p[0x04] & 0x0F;
     return LIBMK_SUCCESS;
 }
+
+
+int libmk_save_profile(LibMK_Handle* handle) {
+     if (handle == NULL)
+         handle = DeviceHandle;
+     if (handle == NULL)
+         return LIBMK_ERR_DEV_NOT_SET;
+     unsigned char* p = libmk_build_packet(2, 0x55, 0x50);
+     return libmk_send_packet(handle, p);
+}
+
+
+int libmk_set_active_profile(LibMK_Handle* handle, unsigned char profile) {
+    if (handle == NULL)
+        handle = DeviceHandle;
+    if (handle == NULL)
+        return LIBMK_ERR_DEV_NOT_SET;
+    if (!(1 <= profile <= 4))
+        return LIBMK_ERR_INVALID_ARG;
+    unsigned char* p = libmk_build_packet(4, 0x51, 0x00, 0x00, profile);
+    return libmk_send_packet(handle, p);
+}
+
+
+int libmk_get_active_profile(LibMK_Handle* handle, unsigned char* profile) {
+    if (handle == NULL)
+        handle = DeviceHandle;
+    if (handle == NULL)
+        return LIBMK_ERR_DEV_NOT_SET;
+    unsigned char* p = libmk_build_packet(1, 0x52);
+    int r = libmk_exch_packet(handle, p);
+    if (r != LIBMK_SUCCESS)
+        return r;
+    *profile = p[3];
+    free(p);
+    return LIBMK_SUCCESS;
+}

--- a/libmk/libmk.c
+++ b/libmk/libmk.c
@@ -1,5 +1,4 @@
-/**
- * Author: RedFantom
+/** Author: RedFantom
  * License: GNU GPLv3
  * Copyright (c) 2018-2019 RedFantom
 */
@@ -57,6 +56,17 @@ const unsigned int ISO[] =
 
 const unsigned char LAYOUT_ANSI = 0;
 const unsigned char LAYOUT_ISO = 1;
+
+const char* LIBMK_MODEL_STRINGS[] = {
+    "MasterKeys Pro L RGB",
+    "MasterKeys Pro S RGB",
+    "MasterKeys Pro L White",
+    "MasterKeys Pro M White",
+    "Unknown Model",
+    "MasterKeys Pro M RGB",
+    "Unknown Model",
+    "MasterKeys Pro S White",
+};
 
 /** Layout matrices
  *
@@ -165,6 +175,18 @@ const unsigned char LIBMK_LAYOUT[2][3][LIBMK_MAX_ROWS][LIBMK_MAX_COLS] = {
     // TODO: If required, Japanese layouts may be added at index 2 of this array
     // TODO: so that it remains compatible with the LibMK_Layout enum and the
     // TODO: firmware defined layout
+};
+
+
+const char* LIBMK_MODEL_STRINGS[] = {
+    "MasterKeys Pro L RGB", // 0
+    "MasterKeys Pro S RGB", // 1
+    "MasterKeys Pro L White", // 2
+    "MasterKeys Pro M White", // 3
+    "Unknown Model", // 4
+    "MasterKeys Pro M RGB", // 5
+    "Unknown Model", // 6
+    "MasterKeys Pro S White",
 };
 
 

--- a/libmk/libmk.h
+++ b/libmk/libmk.h
@@ -50,7 +50,7 @@ typedef enum LibMK_Result {
     LIBMK_ERR_TRANSFER = -10, ///< Failed to transfer data to or from device
     LIBMK_ERR_DESCR = -11, ///< Failed to get libusb device descriptor
     LIBMK_ERR_PROTOCOL = -13, ///< Keyboard interaction protocol error
-    LIBMK_ERR_INV_ARGS = -14, ///< Invalid arguments passed by caller
+    LIBMK_ERR_INVALID_ARG = -14, ///< Invalid arguments passed by caller
 } LibMK_Result;
 
 
@@ -127,7 +127,6 @@ typedef enum LibMK_Model {
 } LibMK_Model;
 
 
-<<<<<<< HEAD
 /** @brief Struct describing a supported USB device
  *
  * This struct may be used as a linked list. Holds information required

--- a/libmk/libmk.h
+++ b/libmk/libmk.h
@@ -127,6 +127,7 @@ typedef enum LibMK_Model {
 } LibMK_Model;
 
 
+<<<<<<< HEAD
 /** @brief Struct describing a supported USB device
  *
  * This struct may be used as a linked list. Holds information required
@@ -144,17 +145,7 @@ typedef struct LibMK_Device {
 
 
 /** @brief Array of strings representing the supported models */
-const char* LIBMK_MODEL_STRINGS[] = {
-    "MasterKeys Pro L RGB", // 0
-    "MasterKeys Pro S RGB", // 1
-    "MasterKeys Pro L White", // 2
-    "MasterKeys Pro M White", // 3
-    "Unknown Model", // 4
-    "MasterKeys Pro M RGB", // 5
-    "Unknown Model", // 6
-    "MasterKeys Pro S White",
-};
-
+const char* LIBMK_MODEL_STRINGS[];
 
 /** @brief Struct describing an opened supported device
  *
@@ -319,14 +310,6 @@ int libmk_reset(LibMK_Handle* handle);
 
 /** @brief Internal function. Return the bDevice USB descriptor property */
 int libmk_get_device_ident(LibMK_Handle* handle);
-<<<<<<< HEAD
-=======
-int libmk_get_firmware_version(LibMK_Handle* handle, LibMK_Firmware** fw);
-int libmk_set_active_profile(LibMK_Handle* handle, char profile);
-int libmk_get_active_profile(LibMK_Handle* handle, char* profile);
-int libmk_save_profile(LibMK_Handle* handle);
-<<<<<<< HEAD
->>>>>>> ce36524... Fix libmk_create_handle
 
 /** @brief Retrieve details on the firmware version of the device
  *
@@ -337,9 +320,9 @@ int libmk_save_profile(LibMK_Handle* handle);
  * @returns LibMK_Result result code, NULL or LibMK_Firmware* in fw
  */
 int libmk_get_firmware_version(LibMK_Handle* handle, LibMK_Firmware** fw);
-=======
+
+
 int libmk_set_control_mode(LibMK_Handle* handle, LibMK_ControlMode mode);
->>>>>>> 748c903... Fix errors during profile control
 
 /** @brief Send a single packet and verify the response
  *
@@ -355,11 +338,7 @@ int libmk_set_control_mode(LibMK_Handle* handle, LibMK_ControlMode mode);
  * pointer.
  */
 int libmk_send_packet(LibMK_Handle* handle, unsigned char* packet);
-<<<<<<< HEAD
-=======
-int libmk_send_recv_packet(LibMK_Handle* handle, unsigned char* packet, bool r);
-unsigned char* libmk_build_packet(unsigned char predef, ...);
->>>>>>> 748c903... Fix errors during profile control
+
 
 /** @brief Exchange a single packet with the keyboard
  *
@@ -373,14 +352,6 @@ unsigned char* libmk_build_packet(unsigned char predef, ...);
  * the response as an error response.
  */
 int libmk_exch_packet(LibMK_Handle* handle, unsigned char* packet);
-
-/** @brief Build a packet using the given data
- *
- * @param predef: Amount of predefined bytes in the packet
- * @param ...: bytes that are predefined, starting from index 0
- * @returns Pointer to the allocated array of bytes
- */
-unsigned char* libmk_build_packet(unsigned char predef, ...);
 
 /** @brief Set effect to be active on keyboard
  *
@@ -488,6 +459,30 @@ int libmk_get_active_profile(LibMK_Handle* handle, char* profile);
  * non-recoverable.
  */
 int libmk_save_profile(LibMK_Handle* handle);
+
+/** @brief Send a packet specifying whether to expect a response
+ *
+ * @param handle: LibMK_Handle of the device to send the packet to. If
+ *    NULL the global device handle is used.
+ * @param packet: Pointer to array of packet to send.
+ * @param r: Whether to expect a response. If ``false``, the function
+ *    still attempts to read a response to make sure that the buffer is
+ *    empty. If ``true``, performs protocol error checks and yields an
+ *    error if no response was received.
+ * @returns LibMK_Result result code
+ */
+int libmk_send_recv_packet(LibMK_Handle* handle, unsigned char* packet, bool r);
+
+/** @brief Build a new packet of data that can be sent to keyboard
+ *
+ * @param predef: Amount of bytes given in the variable arguments
+ * @param ...: Bytes to from index zero of the packet. The amount of
+ *    bytes given must be equal to the amount specified by ``predef``,
+ *    otherwise this function will segfault.
+ * @returns Pointer to the allocated packet with the set bytes. NULL if
+ *    no memory could be allocated.
+ */
+unsigned char* libmk_build_packet(unsigned char predef, ...);
 
 /** Debugging purposes */
 void libmk_print_packet(unsigned char* packet, char* label);

--- a/libmk/libmk.h
+++ b/libmk/libmk.h
@@ -325,6 +325,7 @@ int libmk_get_firmware_version(LibMK_Handle* handle, LibMK_Firmware** fw);
 int libmk_set_active_profile(LibMK_Handle* handle, char profile);
 int libmk_get_active_profile(LibMK_Handle* handle, char* profile);
 int libmk_save_profile(LibMK_Handle* handle);
+<<<<<<< HEAD
 >>>>>>> ce36524... Fix libmk_create_handle
 
 /** @brief Retrieve details on the firmware version of the device
@@ -336,6 +337,9 @@ int libmk_save_profile(LibMK_Handle* handle);
  * @returns LibMK_Result result code, NULL or LibMK_Firmware* in fw
  */
 int libmk_get_firmware_version(LibMK_Handle* handle, LibMK_Firmware** fw);
+=======
+int libmk_set_control_mode(LibMK_Handle* handle, LibMK_ControlMode mode);
+>>>>>>> 748c903... Fix errors during profile control
 
 /** @brief Send a single packet and verify the response
  *
@@ -351,6 +355,11 @@ int libmk_get_firmware_version(LibMK_Handle* handle, LibMK_Firmware** fw);
  * pointer.
  */
 int libmk_send_packet(LibMK_Handle* handle, unsigned char* packet);
+<<<<<<< HEAD
+=======
+int libmk_send_recv_packet(LibMK_Handle* handle, unsigned char* packet, bool r);
+unsigned char* libmk_build_packet(unsigned char predef, ...);
+>>>>>>> 748c903... Fix errors during profile control
 
 /** @brief Exchange a single packet with the keyboard
  *

--- a/libmk/libmk.h
+++ b/libmk/libmk.h
@@ -50,6 +50,7 @@ typedef enum LibMK_Result {
     LIBMK_ERR_TRANSFER = -10, ///< Failed to transfer data to or from device
     LIBMK_ERR_DESCR = -11, ///< Failed to get libusb device descriptor
     LIBMK_ERR_PROTOCOL = -13, ///< Keyboard interaction protocol error
+    LIBMK_ERR_INV_ARGS = -14, ///< Invalid arguments passed by caller
 } LibMK_Result;
 
 
@@ -419,6 +420,45 @@ int libmk_set_single_led(
 int libmk_get_offset(
     unsigned char* offset, LibMK_Handle* handle,
     unsigned char row, unsigned char col);
+
+/** @brief Set the profile active on the device
+ *
+ * @param handle: LibMK_Handle for the device to set the profile on. If
+ *    NULL the global device handle is used.
+ * @param profile: Number of the profile to activate.
+ * @returns LibMK_Result result code
+ *
+ * The MasterKeys series of devices supports four individual lighting
+ * profiles to which settings can be saved. A profile is activated by
+ * changing the control mode and then activating the new profile. Any
+ * changes applied to the lighting of the keyboard are lost when
+ * changing the control mode to profile control.
+ */
+int libmk_set_active_profile(LibMK_Handle* handle, unsigned char profile);
+
+/** @brief Retrieve the number of the active profile on the device
+ *
+ * @param handle: LibMK_Handle for the device to get the number of the
+ *    active profile from. If NULL the global device handle is used.
+ * @param profile: Pointer to the unsigned char to store the number of
+ *    the profile in.
+ * @returns LibMK_Result result code
+ */
+int libmk_get_active_profile(LibMK_Handle* handle, unsigned char* profile);
+
+/** @brief Save the current lighting settings to the active profile
+ *
+ * @param handle: LibMK_Handle for the device to save the changes to. If
+ *    NULL the global device handle is used.
+ * @returns LibMK_Result result code
+ *
+ * Saves the lighting settings to the profile that is returned by
+ * libmk_get_active_profile. The changes persist after releasing control
+ * of the keyboard, and even after power-cycling the keyboard. The
+ * previous lighting configuration in the profile is deleted and
+ * non-recoverable.
+ */
+int libmk_save_profile(LibMK_Handle* handle);
 
 /** Debugging purposes */
 void libmk_print_packet(unsigned char* packet);

--- a/libmk/libmk.h
+++ b/libmk/libmk.h
@@ -143,6 +143,19 @@ typedef struct LibMK_Device {
 } LibMK_Device;
 
 
+/** @brief Array of strings representing the supported models */
+const char* LIBMK_MODEL_STRINGS[] = {
+    "MasterKeys Pro L RGB", // 0
+    "MasterKeys Pro S RGB", // 1
+    "MasterKeys Pro L White", // 2
+    "MasterKeys Pro M White", // 3
+    "Unknown Model", // 4
+    "MasterKeys Pro M RGB", // 5
+    "Unknown Model", // 6
+    "MasterKeys Pro S White",
+};
+
+
 /** @brief Struct describing an opened supported device
  *
  * Result of libmk_set_device(LibMK_Model, LibMK_Handle**). Contains all
@@ -306,6 +319,13 @@ int libmk_reset(LibMK_Handle* handle);
 
 /** @brief Internal function. Return the bDevice USB descriptor property */
 int libmk_get_device_ident(LibMK_Handle* handle);
+<<<<<<< HEAD
+=======
+int libmk_get_firmware_version(LibMK_Handle* handle, LibMK_Firmware** fw);
+int libmk_set_active_profile(LibMK_Handle* handle, char profile);
+int libmk_get_active_profile(LibMK_Handle* handle, char* profile);
+int libmk_save_profile(LibMK_Handle* handle);
+>>>>>>> ce36524... Fix libmk_create_handle
 
 /** @brief Retrieve details on the firmware version of the device
  *
@@ -434,7 +454,7 @@ int libmk_get_offset(
  * changes applied to the lighting of the keyboard are lost when
  * changing the control mode to profile control.
  */
-int libmk_set_active_profile(LibMK_Handle* handle, unsigned char profile);
+int libmk_set_active_profile(LibMK_Handle* handle, char profile);
 
 /** @brief Retrieve the number of the active profile on the device
  *
@@ -444,7 +464,7 @@ int libmk_set_active_profile(LibMK_Handle* handle, unsigned char profile);
  *    the profile in.
  * @returns LibMK_Result result code
  */
-int libmk_get_active_profile(LibMK_Handle* handle, unsigned char* profile);
+int libmk_get_active_profile(LibMK_Handle* handle, char* profile);
 
 /** @brief Save the current lighting settings to the active profile
  *
@@ -461,4 +481,4 @@ int libmk_get_active_profile(LibMK_Handle* handle, unsigned char* profile);
 int libmk_save_profile(LibMK_Handle* handle);
 
 /** Debugging purposes */
-void libmk_print_packet(unsigned char* packet);
+void libmk_print_packet(unsigned char* packet, char* label);

--- a/masterkeys/__init__.py
+++ b/masterkeys/__init__.py
@@ -78,6 +78,13 @@ class Model:
     MODEL_UNKNOWN = -3
 
 
+class ControlMode:
+    FIRMWARE_CTRL = 0x00
+    EFFECT_CTRL = 0x01
+    CUSTOM_CTRL = 0x02
+    PROFILE_CTRL = 0x03
+
+
 MODEL_STRINGS = {
     0: "MasterKeys Pro L RGB",
     5: "MasterKeys Pro M RGB",
@@ -111,9 +118,9 @@ def set_device(model):
         is supported in the Python library. Only the first found device
         of the specified model is controlled.
     :type model: int
-    :return: Result code
+    :return: Result code (:class:`.ResultCode`)
     :rtype: int
-    :raises: TypeError upon invalid argument type
+    :raises: ``TypeError`` upon invalid argument type
     """
     return _mk.set_device(model)
 
@@ -123,7 +130,7 @@ def enable_control():
     """
     Enable control on the device that has been set
 
-    :return: Result code
+    :return: Result code (:class:`.ResultCode`)
     :rtype: int
     """
     return _mk.enable_control()
@@ -134,7 +141,7 @@ def disable_control():
     """
     Disable control on the device that has been set and is controlled
 
-    :return: Result code
+    :return: Result code (:class:`.ResultCode`)
     :rtype: int
     """
     return _mk.disable_control()
@@ -145,11 +152,11 @@ def set_effect(effect):
     """
     Set the effect to be active on the controlled keyboard
 
-    :param effect: Effect number to set to be active
+    :param effect: Effect number to set to be active (:class:`.Effect`)
     :type effect: int
-    :return: Result code
+    :return: Result code (:class:`.ResultCode`)
     :rtype: int
-    :raises: TypeError upon invalid argument type
+    :raises: ``TypeError`` upon invalid argument type
     """
     return _mk.set_effect(effect)
 
@@ -162,10 +169,11 @@ def set_all_led_color(layout):
     :param layout: List of lists of color tuples such as created by
         build_layout_list()
     :type layout: List[List[Tuple[int, int, int], ...], ...]
-    :return: Result code
+    :return: Result code (:class:`.ResultCode`)
     :rtype: int
-    :raises: ValueError if the wrong amount of elements is in the list
-    :raises: TypeError if invalid argument type (any element)
+    :raises: ``ValueError`` if the wrong amount of elements is in the
+        list
+    :raises: ``TypeError`` if invalid argument type (any element)
     """
     return _mk.set_all_led_color(layout)
 
@@ -181,7 +189,7 @@ def set_full_led_color(r, g, b):
     :type g: int
     :param b: blue color byte
     :type b: int
-    :return: Result code
+    :return: Result code (:class:`.ResultCode`)
     :rtype: int
     """
     return _mk.set_full_led_color(r, g, b)
@@ -202,9 +210,9 @@ def set_ind_led_color(row, col, r, g, b):
     :type g: int
     :param b: blue color byte
     :type b: int
-    :return: Result code
+    :return: Result code (:class:`.ResultCode`)
     :rtype: int
-    :raises: TypeError upon invalid argument type
+    :raises: ``TypeError`` upon invalid argument type
     """
     return _mk.set_ind_led_color(row, col, r, g, b)
 
@@ -255,7 +263,7 @@ def set_effect_details(effect, direction=0, speed=0x60, amount=0x00,
     For more details about the parameters, please see the libmk
     documentation.
 
-    :param effect: Effect number
+    :param effect: Effect number (:class:`.Effect`)
     :type effect: int
     :param direction: Direction of the animation of the effect
     :type direction: int
@@ -267,8 +275,57 @@ def set_effect_details(effect, direction=0, speed=0x60, amount=0x00,
     :type foreground: Tuple[int, int, int]
     :param background: Background color of the effect
     :type background: Tuple[int, int, int]
-    :return: Result code
+    :return: Result code (:class:`.ResultCode`)
     :rtype: int
     """
     return _mk.set_effect_details(
         effect, direction, speed, amount, foreground, background)
+
+
+def get_active_profile():
+    # type: () -> int
+    """
+    Return the number of the profile active on the keyboard
+
+    :return: Result code (:class:`.ResultCode`) or profile number
+    :rtype: int
+    """
+    return _mk.get_active_profile()
+
+
+def set_active_profile(profile):
+    # type: (int) -> int
+    """
+    Activate a profile on the keyboard
+
+    :param profile: Number of profile to activate
+    :type profile: int
+    :return: Result code (:class:`.ResultCode`)
+    :rtype: int
+    """
+    return _mk.set_active_profile(profile)
+
+
+def save_profile():
+    # type: () -> int
+    """
+    Save the changes made to the lighting to the active profile
+
+    :return: Result code (:class:`.ResultCode`)
+    :rtype: int
+    """
+    return _mk.save_profile()
+
+
+def set_control_mode(mode):
+    # type: (int) -> int
+    """
+    Change the control mode of the keyboard manually
+
+    :param mode: New control mode to set (:class:`.ControlMode`)
+    :type mode: int  
+    :return: Result code (:class:`.ResultCode`)
+    :rtype: int
+    """
+    return _mk.set_control_mode(mode)
+

--- a/masterkeys/__init__.py
+++ b/masterkeys/__init__.py
@@ -103,8 +103,9 @@ def detect_devices():
     """
     Detect supported connected devices and return a tuple of models
     
-    :return: tuple[int] identifying models
-    :raises: RuntimeError upon internal Python error
+    :return: Tuple of integers (:class:``.Model``)
+    :rtype: Tuple[int, ...]
+    :raises: ``RuntimeError`` upon internal Python error
     """
     return _mk.detect_devices()
 
@@ -221,6 +222,7 @@ def get_device_ident():
     # type: () -> int
     """
     Return the bDevice USB descriptor value for the controlled keyboard
+
     :return: bDevice USB descriptor value or result code (<0)
     :rtype: int
     """
@@ -234,6 +236,11 @@ def set_all_led_color_dict(keys):
 
     The keys should be specified in a dictionary of the format
     {(row, col): (r, g, b)}
+
+    :param keys: Dictionary containing key color data
+    :type keys: Dict[Tuple[int, int], Tuple[int, int, int]]
+    :return: Result code (:class:``.ResultCode``)
+    :rtype: int
     """
     layout = build_layout_list()
     for (row, col), (r, g, b) in keys.items():
@@ -243,7 +250,12 @@ def set_all_led_color_dict(keys):
 
 def build_layout_list():
     # type: () -> List[List[Tuple[int, int, int], ...], ...]
-    """Return a list of the right proportions for full LED layout"""
+    """
+    Return a list of the right proportions for full LED layout
+
+    :return: Empty layout list
+    :rtype: List[List[Tuple[int, int, int], ...], ...]
+    """
     layout = list()
     for i in range(MAX_ROWS):
         column = list()

--- a/masterkeys/masterkeys.c
+++ b/masterkeys/masterkeys.c
@@ -323,7 +323,27 @@ static struct PyMethodDef masterkeys_funcs[] = {
         masterkeys_get_device_ident,
         METH_NOARGS,
         "Return the bDevice USB descriptor value"
-    }, {NULL, NULL, 0, NULL}
+    }, {
+        "get_active_profile",
+        masterkeys_get_active_profile,
+        METH_VARARGS,
+        "Return the number of the active profile"
+    }, {
+        "set_active_profile",
+        masterkeys_set_active_profile,
+        METH_VARARGS,
+        "Set the active profile on the keyboard"
+    }, {
+       "save_profile",
+       masterkeys_save_profile,
+       METH_VARARGS,
+       "Save the changes made to the active profile"
+    }, {
+        "set_control_mode",
+        masterkeys_set_control_mode,
+        METH_VARARGS,
+        "Set the control mode of the keyboard"
+    },{NULL, NULL, 0, NULL}
 };
 
 

--- a/masterkeys/masterkeys.c
+++ b/masterkeys/masterkeys.c
@@ -234,6 +234,42 @@ static PyObject* masterkeys_get_device_ident(PyObject* self, PyObject* args) {
 }
 
 
+static PyObject* masterkeys_get_active_profile(PyObject* self, PyObject* args) {
+    /** Return the active profile on the keyboard */
+    char profile;
+    int r = libmk_get_active_profile(NULL, &profile);
+    if (r != LIBMK_SUCCESS)
+        return NULL;
+    return PyInt_FromLong(profile);
+}
+
+
+static PyObject* masterkeys_set_active_profile(PyObject* self, PyObject* args) {
+    /** Set the active profile on the keyboard */
+    char profile;
+    if (!PyArg_ParseTuple(args, "i", &profile))
+        return NULL;
+    int r = libmk_set_active_profile(NULL, profile);
+    return PyInt_FromLong(r);
+}
+
+
+static PyObject* masterkeys_save_profile(PyObject* self, PyObject* args) {
+    /** Save changes made to the active profile */
+    int r = libmk_save_profile(NULL);
+    return PyInt_FromLong(r);
+}
+
+
+static PyObject* masterkeys_set_control_mode(PyObject* self, PyObject* args) {
+    /** Set the control mode on the keyboard */
+    LibMK_ControlMode mode;
+    if (!PyArg_ParseTuple(args, "i", &mode))
+        return NULL;
+    return PyInt_FromLong(libmk_set_control_mode(NULL, mode));
+}
+
+
 static struct PyMethodDef masterkeys_funcs[] = {
     {
         "detect_devices",

--- a/masterkeys/masterkeys.c
+++ b/masterkeys/masterkeys.c
@@ -246,7 +246,7 @@ static PyObject* masterkeys_get_active_profile(PyObject* self, PyObject* args) {
 
 static PyObject* masterkeys_set_active_profile(PyObject* self, PyObject* args) {
     /** Set the active profile on the keyboard */
-    char profile;
+    long profile;
     if (!PyArg_ParseTuple(args, "i", &profile))
         return NULL;
     int r = libmk_set_active_profile(NULL, profile);
@@ -343,7 +343,7 @@ static struct PyMethodDef masterkeys_funcs[] = {
         masterkeys_set_control_mode,
         METH_VARARGS,
         "Set the control mode of the keyboard"
-    },{NULL, NULL, 0, NULL}
+    }, {NULL, NULL, 0, NULL}
 };
 
 

--- a/utils/main.c
+++ b/utils/main.c
@@ -5,8 +5,14 @@
 */
 #include "../libmk/libmk.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include "libusb.h"
+
+
+int max(int a, int b) {
+    return a > b ? a : b;
+}
 
 
 int main(void) {
@@ -20,7 +26,7 @@ int main(void) {
     int n = libmk_detect_devices(&models);
     printf("Detected %d devices.\n", n);
     for (int i = 0; i < n; i++) {
-        printf("  Detected device: %d, %s\n", models[i], LIBMK_MODEL_STRINGS[i]);
+        printf("Detected device: %d, %s\n", models[i], LIBMK_MODEL_STRINGS[i]);
         
         printf("  Enabling device... ");
         int r = libmk_set_device(models[i], NULL);
@@ -50,6 +56,14 @@ int main(void) {
         } else
             printf("Failed: %d.\n", r);
         
+        char profile;
+        printf("  Retrieving active profile... ");
+        r = libmk_get_active_profile(NULL, &profile);
+        if (r == LIBMK_SUCCESS)
+            printf("Done: %d.\n", profile);
+        else
+            printf("Failed: %d.\n", r);
+        
         printf("  Setting full color... ");
         r = libmk_set_full_color(NULL, 255, 255, 0);
         if (r != LIBMK_SUCCESS)
@@ -65,15 +79,27 @@ int main(void) {
         else
             printf("Done.\n");
         sleep(2);
+        
+        printf("  Setting active profile... ");
+        r = libmk_set_active_profile(NULL, 4);
+        if (r != LIBMK_SUCCESS)
+            printf("Failed: %d.\n", r);
+        else
+            printf("Done.\n");
+    
+        printf("  Retrieving active profile... ");
+        r = libmk_get_active_profile(NULL, &profile);
+        if (r == LIBMK_SUCCESS)
+            printf("Done: %d.\n", profile);
+        else
+            printf("Failed: %d.\n", r);
 
-        int color = 200;
         unsigned char colors[LIBMK_MAX_ROWS][LIBMK_MAX_COLS][3] = {0};
         for (short row=0; row < LIBMK_MAX_ROWS; row++)
             for (short col=0; col < LIBMK_MAX_COLS; col++) {
-                color += 8;
-                colors[row][col][(color / 256 + 1) % 3] = 0xFF -(color % 256);
-                colors[row][col][(color / 256) % 3] = 0xFF - (color % 128);
-                colors[row][col][(color / 256 + 2) % 3] = 0xFF - (color % 64);
+                colors[row][col][0] = 0;
+                colors[row][col][1] = 50 * row;
+                colors[row][col][2] = 200;
             }
         printf("  Setting LED pattern... ");
         r = libmk_set_all_led_color(NULL, (unsigned char*) colors);
@@ -82,6 +108,13 @@ int main(void) {
         else
             printf("Done.\n");
         sleep(4);
+    
+        printf("  Saving to profile %d... ", profile);
+        r = libmk_save_profile(NULL);
+        if (r == LIBMK_SUCCESS)
+            printf("Done.\n");
+        else
+            printf("Failed: %d.\n", r);
         
         printf("  Setting single LED... ");
         r = libmk_set_single_led(NULL, 0, 0, 255, 255, 0);
@@ -91,14 +124,6 @@ int main(void) {
             printf("Failed: %d.\n", r);
         sleep(2);
         
-        printf("  Retrieving active profile. ");
-        char profile;
-        r = libmk_get_active_profile(NULL, &profile);
-        if (r == LIBMK_SUCCESS)
-            printf("Done.\n    Profile: %d.\n", profile);
-        else
-            printf("Failed: %d.\n", r);
-        
         printf("  Disabling LED control... ");
         r = libmk_disable_control(NULL);
         if (r != LIBMK_SUCCESS)
@@ -106,8 +131,7 @@ int main(void) {
         else
             printf("Done.\n");
         libmk_reset(NULL);
-
-        libmk_exit();
     }
+    libmk_exit();
     return 0;
 }

--- a/utils/main.c
+++ b/utils/main.c
@@ -11,45 +11,60 @@
 
 int main(void) {
     /** Run some tests on the masterkeys library */
-    libmk_init();
-    printf("Device: %d\n", libmk_ident_model("MasterKeys Pro S White"));
+    bool c = libmk_init();
+    if (!c) {
+        printf("Failed to initialize LibMK Library.\n");
+        return -1;
+    }
     LibMK_Model* models = NULL;
     int n = libmk_detect_devices(&models);
     printf("Detected %d devices.\n", n);
     for (int i = 0; i < n; i++) {
-        printf("  Detected: %d\n", models[i]);
+        printf("  Detected device: %d, %s\n", models[i], LIBMK_MODEL_STRINGS[i]);
+        
+        printf("  Enabling device... ");
         int r = libmk_set_device(models[i], NULL);
-        if (r != LIBMK_SUCCESS)
-            printf("  Enabling this device failed: %d.\n", r);
-        else
-            printf("  Enabled this device.\n");
+        if (r == LIBMK_SUCCESS)
+            printf("Done.\n");
+        else {
+            printf("Failed: %d.\n", r);
+            continue;
+        }
+        
+        printf("  Acquiring control... ");
         r = libmk_enable_control(NULL);
         if (r != LIBMK_SUCCESS) {
-            printf("  Enabling LED control failed: %d.\n", r);
+            printf("Failed: %d.\n", r);
             libmk_reset(NULL);
             continue;
         } else
-            printf("  Enabled LED control.\n");
+            printf("Done.\n");
+        
         LibMK_Firmware* fw;
+        printf("  Retrieving firmware info... ");
         r = libmk_get_firmware_version(NULL, &fw);
         if (r == LIBMK_SUCCESS) {
+            printf("Done.\n");
             printf("    Keyboard firmware version: %s\n", fw->string);
             printf("    Keyboard firmware layout: %d\n", fw->layout);
-        }
+        } else
+            printf("Failed: %d.\n", r);
+        
+        printf("  Setting full color... ");
         r = libmk_set_full_color(NULL, 255, 255, 0);
-        if (r != LIBMK_SUCCESS) {
-            printf("    Setting full color failed.\n");
-        } else {
-            printf("    Setting full color done.\n");
-        }
+        if (r != LIBMK_SUCCESS)
+            printf("Failed: %d\n", r);
+        else
+            printf("Done.\n");
         sleep(1);
+        
+        printf("  Setting LED effect... ");
         r = libmk_set_effect(NULL, LIBMK_EFF_WAVE);
         if (r != LIBMK_SUCCESS)
-            printf("  Failed to set LED effect: %d\n", r);
-        else {
-            printf("  LED Effect set.\n");
-            sleep(2);
-        }
+            printf("Failed: %d.\n", r);
+        else
+            printf("Done.\n");
+        sleep(2);
 
         int color = 200;
         unsigned char colors[LIBMK_MAX_ROWS][LIBMK_MAX_COLS][3] = {0};
@@ -60,21 +75,36 @@ int main(void) {
                 colors[row][col][(color / 256) % 3] = 0xFF - (color % 128);
                 colors[row][col][(color / 256 + 2) % 3] = 0xFF - (color % 64);
             }
-        printf("  Enabling all LEDs.\n");
+        printf("  Setting LED pattern... ");
         r = libmk_set_all_led_color(NULL, (unsigned char*) colors);
         if (r != LIBMK_SUCCESS)
-            printf("  Failed to set all LEDs.\n");
+            printf("Failed: %d.\n", r);
+        else
+            printf("Done.\n");
         sleep(4);
         
-        printf("  Enabling single LED.\n");
+        printf("  Setting single LED... ");
         r = libmk_set_single_led(NULL, 0, 0, 255, 255, 0);
+        if (r == LIBMK_SUCCESS)
+            printf("Done.\n");
+        else
+            printf("Failed: %d.\n", r);
         sleep(2);
-
+        
+        printf("  Retrieving active profile. ");
+        char profile;
+        r = libmk_get_active_profile(NULL, &profile);
+        if (r == LIBMK_SUCCESS)
+            printf("Done.\n    Profile: %d.\n", profile);
+        else
+            printf("Failed: %d.\n", r);
+        
+        printf("  Disabling LED control... ");
         r = libmk_disable_control(NULL);
         if (r != LIBMK_SUCCESS)
-            printf("  Disabling LED control failed: %d.\n", r);
+            printf("Failed: %d.\n", r);
         else
-            printf("  Disabled LED control.\n");
+            printf("Done.\n");
         libmk_reset(NULL);
 
         libmk_exit();


### PR DESCRIPTION
The commits in this branch add the following functions:
- `set_active_profile` to change the profile controlled on the keyboard
- `get_active_profile` to return the profile active on the keyboard
- `save_profile` to save the changes made to the settings to the active keyboard profile
- `set_control_mode`  to change the mode of control the keyboard is in (low-level function exposed to the library for very specific purposes)

They have been tested and work properly in C and Python (though proper unit tests for Python should be added at a later stage).